### PR TITLE
Fix some ssl links and use relative urls for own css and js

### DIFF
--- a/_data/kaupungit.yml
+++ b/_data/kaupungit.yml
@@ -180,7 +180,7 @@
   lat: 60.87289
   lon: 26.69156
   osoite: Savonkatu 23, kolmas kerros
-  url: http://hacklabkouvola.fi/
+  url: https://hacklabkouvola.fi/
   status: active
   txt: Kaakkois-Suomen ensimmäinen yhteisöllinen työtila
   pin: "kouvola_pin.png"

--- a/_includes/blog_title.html
+++ b/_includes/blog_title.html
@@ -1,7 +1,7 @@
 <!-- blog title include -->
 {% if page.lang == 'en' %}
-<h1 class="blog-title"><a href="{{ site.url }}{{ site.baseurl }}/blog/index_en.html">hacklab.fi blog</a></h1>
-<a href="{{ site.url }}{{ site.baseurl }}/blog/index_en.html">All blog posts &raquo;</a>
+<h1 class="blog-title"><a href="/blog/index_en.html">hacklab.fi blog</a></h1>
+<a href="/blog/index_en.html">All blog posts &raquo;</a>
 {% else %}
-<h1 class="blog-title"><a href="{{ site.url }}{{ site.baseurl }}/blog/index.html">hacklab.fi blog</a></h1>
-<a href="{{ site.url }}{{ site.baseurl }}/blog/index.html">Kaikki blogikirjoitukset &raquo;</a>{% endif %}
+<h1 class="blog-title"><a href="/blog/index.html">hacklab.fi blog</a></h1>
+<a href="/blog/index.html">Kaikki blogikirjoitukset &raquo;</a>{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <section class="footer" id="footer">
   <div class="container">
-    <img class="logo" src="{{ site.url }}{{ site.baseurl }}/assets/images/hacklab_fi_logo.png" alt="hacklab.fi logo"/>
+    <img class="logo" src="/assets/images/hacklab_fi_logo.png" alt="hacklab.fi logo"/>
     {% if page.lang == 'fi' %}
       <p class="text-info">hacklab.fi – hackerspacet ja makerspacet Suomessa.</p><p class="text-info">Itsenäisten ja avointen työtilojen yhteistyöverkosto. Kaikki jäsenryhmämme ovat jäsentensä ylläpitämiä yleishyödyllisiä yhdistyksiä</p><p class="text-info">Ota meihin yhteyttä IRC-kanavalla #hacklab.fi Freenode-verkossa.</p>
     {% else %}

--- a/_includes/navi.html
+++ b/_includes/navi.html
@@ -13,7 +13,7 @@
     <div id="navbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
         <li>
-          <a href="http://discourse.hacklab.fi">Discourse Forum</a>
+          <a href="https://discourse.hacklab.fi">Discourse Forum</a>
         </li>
         <li>
           {% if page.lang == 'fi' %}<a href="{{ site.url }}{{ site.baseurl }}/info.html">Hacklab?</a>

--- a/_includes/navi.html
+++ b/_includes/navi.html
@@ -20,8 +20,8 @@
           {% else %}<a href="{{ site.url }}{{ site.baseurl }}/info_en.html">Hacklab?</a>{% endif %}
         </li>
         <li>
-          {% if page.lang == 'fi' %}<a href="http://robotit.hacklab.fi">Robotit Strömbergin puistossa</a>
-          {% else %}<a href="http://robotit.hacklab.fi/index_en.html">Robots in Strömberg park</a>{% endif %}
+          {% if page.lang == 'fi' %}<a href="https://robotit.hacklab.fi">Robotit Strömbergin puistossa</a>
+          {% else %}<a href="https://robotit.hacklab.fi/index_en.html">Robots in Strömberg park</a>{% endif %}
         </li>
       </ul>
       <ul class="nav navbar-nav navbar-right">

--- a/_includes/navi.html
+++ b/_includes/navi.html
@@ -7,8 +7,8 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      {% if page.lang == 'fi' %}<a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/index.html">hacklab.fi</a>
-      {% else %}<a class="navbar-brand" href="{{ site.url }}{{ site.baseurl }}/index_en.html">hacklab.fi</a>{% endif %}
+      {% if page.lang == 'fi' %}<a class="navbar-brand" href="/index.html">hacklab.fi</a>
+      {% else %}<a class="navbar-brand" href="/index_en.html">hacklab.fi</a>{% endif %}
     </div>
     <div id="navbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
@@ -16,8 +16,8 @@
           <a href="https://discourse.hacklab.fi">Discourse Forum</a>
         </li>
         <li>
-          {% if page.lang == 'fi' %}<a href="{{ site.url }}{{ site.baseurl }}/info.html">Hacklab?</a>
-          {% else %}<a href="{{ site.url }}{{ site.baseurl }}/info_en.html">Hacklab?</a>{% endif %}
+          {% if page.lang == 'fi' %}<a href="/info.html">Hacklab?</a>
+          {% else %}<a href="/info_en.html">Hacklab?</a>{% endif %}
         </li>
         <li>
           {% if page.lang == 'fi' %}<a href="https://robotit.hacklab.fi">Robotit Strömbergin puistossa</a>
@@ -26,8 +26,8 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li>
-          {% if page.lang == 'en' %}<a href="{{ site.url }}{{ site.baseurl }}/index.html">Suomeksi</a>
-          {% else %}<a href="{{ site.url }}{{ site.baseurl }}/index_en.html">In English</a>{% endif %}
+          {% if page.lang == 'en' %}<a href="/index.html">Suomeksi</a>
+          {% else %}<a href="/index_en.html">In English</a>{% endif %}
         </li>
       </ul>
     </div>

--- a/_includes/this_post.html
+++ b/_includes/this_post.html
@@ -1,6 +1,6 @@
 <!-- this post include -->
 <article class="post post-decorative clearfix">
-  <img src="{{ site.url }}{{ site.baseurl }}/posts_images/{{ this_post.image }}" alt="Kuvituskuva" class="post-image" />
+  <img src="/posts_images/{{ this_post.image }}" alt="Kuvituskuva" class="post-image" />
   <h2 class="post-title"><a href="{{ this_post.url | relative_url }}">{% if page.lang == 'en' and this_post.translation_en %}{{ this_post.translation_title_en }}{% else %}{{ this_post.title | escape }}{% endif %}</a></h2>
   <span class="post-meta">{{ this_post.date | date: "%-d %B %Y" }}</span>
   {% if page.lang == 'en' and this_post.translation_en %}<p>{{ this_post.translation_en | strip_html | truncatewords: 50}} ...</p>{% else %}{{ this_post.excerpt}}{%if this_post.content != this_post.excerpt %} ...{% endif %}{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@ pagepath {{ page.path }}
     <!-- page styles -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/assets/uusi.css?{{site.time | date: '%s'}}"/>
+    <link rel="stylesheet" href="/assets/uusi.css?{{site.time | date: '%s'}}"/>
 
 
     <!-- fonts -->
@@ -42,8 +42,8 @@ pagepath {{ page.path }}
 
 
     <!-- leaflet map -->
-    <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/assets/leaflet/leaflet.css"/>
-    <script src="{{ site.url }}{{ site.baseurl }}/assets/leaflet/leaflet.js"></script>
+    <link rel="stylesheet" href="/assets/leaflet/leaflet.css"/>
+    <script src="/assets/leaflet/leaflet.js"></script>
 
 {% if page.custom_js %}
   {% for js_file in page.custom_js %}

--- a/_layouts/kaupungit.html
+++ b/_layouts/kaupungit.html
@@ -5,7 +5,7 @@ lang: fi
 
 {% for k in site.data.kaupungit %}
   <div class="post clearfix" id="{{ k.id }}">
-    {% if k.logo %}<img class="city-logo" src="{{ site.url }}{{ site.baseurl }}/assets/images/logos/{{ k.logo }}" alt="{{ k.kaupunki }} logo" class="hidden-xs" />{% endif %}
+    {% if k.logo %}<img class="city-logo" src="/assets/images/logos/{{ k.logo }}" alt="{{ k.kaupunki }} logo" class="hidden-xs" />{% endif %}
     <h2>{{ k.kaupunki }}
     {% if k.status == 'active' %}
       <span class="city-status">aktiivinen</span>
@@ -16,7 +16,7 @@ lang: fi
     {% elsif k.status == 'restructuring' %}
       <span class="city-status">vaihtelevat tapaamiset</span>
     {% endif %}</h2>
-    {% if k.osoite %}<p>{% if k.osm_node %}<a href="http://www.openstreetmap.org/node/{{ k.osm_node }}">{% endif %}{{ k.osoite }}{% if k.osm_node %}</a>{% endif %}{% endif   %}
+    {% if k.osoite %}<p>{% if k.osm_node %}<a href="https://www.openstreetmap.org/node/{{ k.osm_node }}">{% endif %}{{ k.osoite }}{% if k.osm_node %}</a>{% endif %}{% endif   %}
     {% if k.url and k.url contains '://' %}<p><a href="{{ k.url }}">{{ k.url }}</a></p>{% endif %}
     <p>{{ k.txt }}</p>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ header: n
 {% include blog_title.html %}
 
 <div class="post post-decorative clearfix">
-  <img src="{{ site.url }}{{ site.baseurl }}/posts_images/{{ page.image }}" alt="Kuvituskuva" class="post-image" />
+  <img src="/posts_images/{{ page.image }}" alt="Kuvituskuva" class="post-image" />
   <h2 class="post-title">{{ page.title }}</h2>
   <span class="post-meta">{{ post.date | date: date_to_string }}</span>
   {{ content }}

--- a/_posts/2018-05-15-Robotit_Strombergin_puistossa.markdown
+++ b/_posts/2018-05-15-Robotit_Strombergin_puistossa.markdown
@@ -11,11 +11,11 @@ translation_en: |
 
   Robots from near and far will race on a track. The family event is part of Summer HSF at Helsinki Hacklab.
 
-  More info on website http://robotit.hacklab.fi/index_en.html.
+  More info on website https://robotit.hacklab.fi/index_en.html.
 translation_title_en: "Robots at Strömberg park 2018"
 ---
 Robotit saapuvat taas Strömbergin puistoon Helsingissä! Uusi kisa järjestetään lauantaina 9. kesäkuuta klo 16 alkaen. Tapahtuma on avoin ja ilmainen kaikille.
 
 Mukana kisassa radalla on robotteja läheltä ja kauempaa Suomessa. Perhetapahtuma on osa hacklabien yhteistä kesän HSF-tapahtumaa Helsinki Hacklabilla.
 
-Lisää tietoa tapahtumasta osoitteessa [robotit.hacklab.fi](http://robotit.hacklab.fi)!
+Lisää tietoa tapahtumasta osoitteessa [robotit.hacklab.fi](https://robotit.hacklab.fi)!

--- a/assets/map.js
+++ b/assets/map.js
@@ -25,11 +25,11 @@ L.tileLayer("https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={
 {% for k in all_cities %}
 {% if k.pin %}
 var icon_{{ forloop.index }} = L.icon({
-    iconUrl: '{{ site.url }}{{ site.baseurl }}/assets/leaflet/images/{{k.pin}}',
+    iconUrl: '/assets/leaflet/images/{{k.pin}}',
 
-    iconSize:     [50, 79], 
-    iconAnchor:   [25, 79], 
-    popupAnchor:  [0, -40] 
+    iconSize:     [50, 79],
+    iconAnchor:   [25, 79],
+    popupAnchor:  [0, -40]
 });
 {% endif %}
 {% if k.lat and k.lon %}


### PR DESCRIPTION
Fixes some found urls that can be ssl in navigation (like discourse)
Load own css and js from relative urls to support ssl
* this might have worked with {{ site.url }} also, but I'm not sure and cannot test right now (depends if github sets it correctly or not)
* There are still few meta tags that use site.url (twitter:image and og:image) 

After this has been merged this setting can be set on (and hopefully everything works :) https://help.github.com/articles/securing-your-github-pages-site-with-https/