### PR TITLE
Add bankaccount and link to prh

### DIFF
--- a/hacklab_ry.md
+++ b/hacklab_ry.md
@@ -7,6 +7,8 @@ lang: fi
 
 Hacklab ry. on hacklab.fi-yhteistyöverkoston vuonna 2019 perustama kattojärjestö, joka toimii jäsenyhdistystensä eduksi koko Suomen alueella.
 
+Yhdistyksen [rekisteritiedot](https://yhdistysrekisteri.prh.fi/basicinformation?userLang=fi&businessId=3084371-1){:target="_blank"}
+
 ## Yhteistyö
 
 Yhteistyöhistoriaa hacklab.fi-verkostolla on ollut vuodesta 2012 alkaen, ja kattojärjestö jatkaa tätä mahdollistamalla entistä paremmin yhteisiä resursseja ja vastun jakamista toiminnan kehittämisessä. Kattojärjestössä toimii hallitus, joka vastaa budjetoinnista, kokousten kutsumisesta ja muista sääntömääräisistä tehtävistä.
@@ -37,3 +39,7 @@ Esimerkiksi
 > Yhdistyksen/hallituksen kokous kannatti [äänestyksessä] Hacklab ry.:n varsinaisen jäsenyyden hakemista (y-tunnus 3084371-1) sekä liiton sääntöjen ja tarkoituksen hyväksymistä.
 
 Mikäli yhdistyksen säännöt tai yhdistyksen kokouksen muu päätös ei toisin määrää, liittymispäätöksen voi tehdä yhdistyksen hallitus. Liiton suositus on tehdä päätös yhdistyksen kokouksessa. Jäsenyyden hakemisesta on syytä mainita kokouksen kutsussa ja tarjota linkki [liiton sääntöihin](/saannot.html), jotta osallistujilla on ollut riittävästi aikaa tutustua niihin ennen päätöstä.
+
+## Tilinumero
+
+IBAN-tilinumeromme on FI45 5670 0820 3659 12. Otamme vastaan lahjoituksia. Mikäli teet lahjoituksen, ilmoitathan siitä hallitukselle.

--- a/hacklab_ry.md
+++ b/hacklab_ry.md
@@ -42,4 +42,4 @@ Mikäli yhdistyksen säännöt tai yhdistyksen kokouksen muu päätös ei toisin
 
 ## Tilinumero
 
-IBAN-tilinumeromme on FI45 5670 0820 3659 12. Otamme vastaan lahjoituksia. Mikäli teet lahjoituksen, ilmoitathan siitä hallitukselle.
+IBAN-tilinumeromme on `FI45 5670 0820 3659 12`, otamme vastaan lahjoituksia, lahjoituksien viitenumero `RF43 3800 1`. Halutessasi voit viestittää lahjoituksestasi [hallitukselle](mailto:hallitus@tampere.hacklab.fi){:target="_blank"}

--- a/hacklab_ry_en.md
+++ b/hacklab_ry_en.md
@@ -7,6 +7,9 @@ lang: en
 
 Hacklab ry. *(registered association)* is an umbrella ogranisation founded by hacklab.fi cooperation network in 2019, which acts for benefit of its member organisations all across Finland.
 
+Association [register information](https://yhdistysrekisteri.prh.fi/basicinformation?userLang=en&businessId=3084371-1){:target="_blank"}
+
+
 ## Cooperation
 
 History of hacklab.fi cooperation network starts from 2012, and the umbrella organisation continues this by enabling better common resources and sharing responsibility for developing operations. The organisation has a commitee which is in charge of the budget, calling for meetings and other duties mentioned in the rules.
@@ -28,3 +31,7 @@ Purposes of the organisation briefly are:
  - be in charge of shared funds and resources
 
 [Complete official rules of the organisation only available in Finnish](/saannot.html)
+
+## Bank account
+
+IBAN-number FI45 5670 0820 3659 12. We accept donations. If you make a donation, please notify the board.

--- a/hacklab_ry_en.md
+++ b/hacklab_ry_en.md
@@ -34,4 +34,4 @@ Purposes of the organisation briefly are:
 
 ## Bank account
 
-IBAN-number FI45 5670 0820 3659 12. We accept donations. If you make a donation, please notify the board.
+Our IBAN account number is `FI45 5670 0820 3659 12`. We accept donations please use reference number `RF43 3800 1`. If you want, you can tell [the board](mailto:hallitus@tampere.hacklab.fi){:target="_blank"} about your donation.


### PR DESCRIPTION
Add bank account information with a note that we accept donations
Add link to Information Service of the Finnish Register of Associations (PRH)