### PR TITLE
Tech Club Joensuu is closing, change status to restructuring

### DIFF
--- a/_data/kaupungit.yml
+++ b/_data/kaupungit.yml
@@ -209,7 +209,7 @@
   url: http://tcj.fi/
   rss_url: http://tcj.fi/feed/
   osm_node: 4161097330
-  status: active
+  status: restructuring
   txt: "Joensuun edustus hacklab.fi:ssa. Sijaitsee veturitalleilla. Ovet avoinna keskiviikkoisin klo 17-20."
   pin: "joensuu_pin.png"
   logo: "joensuu.jpg"


### PR DESCRIPTION
As per discussion in matrix channel #general:hacklab.fi and status update on http://tcj.fi/ site, moving Tech Club Joensuu to restructuring