### PR TITLE
Remove Kuopio from lists and map

### DIFF
--- a/_data/kaupungit.yml
+++ b/_data/kaupungit.yml
@@ -187,7 +187,7 @@
   registeredon: 2015-09-15
   url: http://kuopio.hacklab.fi/
   rss_url: http://kuopio.hacklab.fi/blog/feed/
-  status: restructuring
+  status: closed
   osm_node: 4380469615
   txt: "Kuopion Hacklab"
   pin: "kuopio_pin.png"


### PR DESCRIPTION
Closed status is not yet really implemented (see issue #55) but as closed is not a valid status at the moment it wont show on the page.