### PR TITLE
Change seinäjoki to restructuring

### DIFF
--- a/_data/kaupungit.yml
+++ b/_data/kaupungit.yml
@@ -350,8 +350,8 @@
   registeredon: 2016-11-22
   url: http://seinajoki.hacklab.fi/
   rss_url: http://seinajoki.hacklab.fi/feed.xml
-  status: active
-  txt: "Omat tilat 2019 alkaen!"
+  status: restructuring
+  txt: "Tiloista jouduttu luopumaan."
   pin: "seinajoki_pin.png"
   logo: "seinajoki.png"
   irc: "#SjkHacklab"


### PR DESCRIPTION
user "Rakholl" informed on hacklab.fi matrix channel that Seinäjoki is restructuring

<img width="738" alt="image" src="https://user-images.githubusercontent.com/1352132/218531782-d194d5fc-687e-4f82-9e4e-61e70a565146.png">
